### PR TITLE
Fix pack creation continue button logic

### DIFF
--- a/src/components/CreatePackModal.jsx
+++ b/src/components/CreatePackModal.jsx
@@ -90,7 +90,7 @@ const CreatePackModal = ({ isOpen, onClose, onPackCreated, editingPack = null })
               title: freshPackData.title || '',
               category: freshPackData.category || '',
               subcategory: freshPackData.subcategory || '',
-              packType: freshPackData.packType || '',
+              packType: freshPackData.packType || 'download',
               description: freshPackData.description || '',
               price: freshPackData.price != null ? String(freshPackData.price) : '',
               discount: freshPackData.discount != null ? String(freshPackData.discount) : '',
@@ -108,7 +108,7 @@ const CreatePackModal = ({ isOpen, onClose, onPackCreated, editingPack = null })
               title: editingPack.title || '',
               category: editingPack.category || '',
               subcategory: editingPack.subcategory || '',
-              packType: editingPack.packType || '',
+              packType: editingPack.packType || 'download',
               description: editingPack.description || '',
               price: editingPack.price != null ? String(editingPack.price) : '',
               discount: editingPack.discount != null ? String(editingPack.discount) : '',
@@ -128,7 +128,7 @@ const CreatePackModal = ({ isOpen, onClose, onPackCreated, editingPack = null })
             title: editingPack.title || '',
             category: editingPack.category || '',
             subcategory: editingPack.subcategory || '',
-            packType: editingPack.packType || '',
+            packType: editingPack.packType || 'download',
             description: editingPack.description || '',
             price: editingPack.price != null ? String(editingPack.price) : '',
             discount: editingPack.discount != null ? String(editingPack.discount) : '',
@@ -165,7 +165,7 @@ const CreatePackModal = ({ isOpen, onClose, onPackCreated, editingPack = null })
       title: '',
       category: '',
       subcategory: '',
-      packType: '',
+      packType: 'download',
       description: '',
       price: '',
       discount: '',
@@ -480,7 +480,6 @@ const CreatePackModal = ({ isOpen, onClose, onPackCreated, editingPack = null })
         if (!formData.title.trim()) return false;
         if (!formData.category) return false;
         if (subcategoriesMap[formData.category]?.length && !formData.subcategory) return false;
-        if (!formData.packType) return false;
         return true;
       case 1: // description
         return formData.description.trim().length >= 50;


### PR DESCRIPTION
Fix 'Continuar' button being blocked in pack creation by defaulting `packType` and removing its validation from step 0.

The 'Continuar' button was disabled because `packType` was a required field in step 0 validation, but it could be empty in new forms or when editing packs without this field explicitly set. This prevented progression even when KYC conditions were met or not applicable.

---
<a href="https://cursor.com/background-agent?bcId=bc-08c92c9f-ea49-445c-b96d-2bc4616492ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-08c92c9f-ea49-445c-b96d-2bc4616492ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

