### PR TITLE
Adjust discount logic for services and packs

### DIFF
--- a/src/components/CreatePackModal.jsx
+++ b/src/components/CreatePackModal.jsx
@@ -477,7 +477,7 @@ const CreatePackModal = ({ isOpen, onClose, onPackCreated, editingPack = null })
     if (formData.discount === '') return null;
     const v = parseInt(formData.discount, 10);
     if (isNaN(v)) return 'Desconto deve ser um número';
-    if (v < 0 || v > 100) return 'Desconto deve estar entre 0 e 100';
+    if (v < 0 || v > 75) return 'Desconto deve estar entre 0 e 75%';
     return null;
   };
 
@@ -496,7 +496,7 @@ const CreatePackModal = ({ isOpen, onClose, onPackCreated, editingPack = null })
       case 1: // description
         return formData.description.trim().length >= 50;
       case 2: // pricing
-        return !getPriceError() && !getDiscountError();
+        return !getPriceError() && !getDiscountError() && !getSellerEarningsValidationError();
       case 3: // media
         // cover is required as per create-pack.js
         return Boolean(coverImageFile || formData.coverImage);
@@ -552,6 +552,15 @@ const CreatePackModal = ({ isOpen, onClose, onPackCreated, editingPack = null })
     return Math.max(final, 0);
   };
 
+  // Validation for minimum seller earnings (10 VC)
+  const getSellerEarningsValidationError = () => {
+    const effectivePriceValue = effectivePrice();
+    if (effectivePriceValue < 10) {
+      return `O valor final para a vendedora deve ser pelo menos 10,00 VC. Valor atual: ${formatVC(effectivePriceValue)}`;
+    }
+    return null;
+  };
+
   const handleSubmit = async () => {
     if (!currentUser || isSubmitting) return;
 
@@ -586,6 +595,8 @@ const CreatePackModal = ({ isOpen, onClose, onPackCreated, editingPack = null })
     if (priceErr) return showError(priceErr);
     const discountErr = getDiscountError();
     if (discountErr) return showError(discountErr);
+    const sellerEarningsErr = getSellerEarningsValidationError();
+    if (sellerEarningsErr) return showError(sellerEarningsErr);
     if (!coverImageFile && !formData.coverImage) {
       return showError('Você deve carregar uma imagem de capa');
     }
@@ -974,17 +985,25 @@ const CreatePackModal = ({ isOpen, onClose, onPackCreated, editingPack = null })
                   id="pack-discount"
                   type="number"
                   min="0"
-                  max="100"
+                  max="75"
                   step="1"
                   value={formData.discount}
                   onChange={e => handleInputChange('discount', e.target.value)}
                   className={getDiscountError() ? 'error' : ''}
                   placeholder="0"
                 />
+                <small>Desconto opcional (0-75%)</small>
                 {getDiscountError() && (
                   <div className="validation-error">
                     <i className="fas fa-exclamation-triangle"></i>
                     {getDiscountError()}
+                  </div>
+                )}
+                
+                {getSellerEarningsValidationError() && (
+                  <div className="validation-error">
+                    <i className="fas fa-exclamation-triangle"></i>
+                    {getSellerEarningsValidationError()}
                   </div>
                 )}
               </div>

--- a/src/components/CreateServiceModal.jsx
+++ b/src/components/CreateServiceModal.jsx
@@ -332,7 +332,7 @@ const CreateServiceModal = ({ isOpen, onClose, onServiceCreated, editingService 
     if (formData.discount === '') return null;
     const v = parseInt(formData.discount, 10);
     if (isNaN(v)) return 'Desconto deve ser um número';
-    if (v < 0 || v > 100) return 'Desconto deve estar entre 0 e 100';
+    if (v < 0 || v > 75) return 'Desconto deve estar entre 0 e 75%';
     return null;
   };
 
@@ -351,6 +351,15 @@ const CreateServiceModal = ({ isOpen, onClose, onServiceCreated, editingService 
     return Math.max(final, 0);
   };
 
+  // Validation for minimum seller earnings (10 VC)
+  const getSellerEarningsValidationError = () => {
+    const effectivePriceValue = effectivePrice();
+    if (effectivePriceValue < 10) {
+      return `O valor final para a vendedora deve ser pelo menos 10,00 VC. Valor atual: ${formatVC(effectivePriceValue)}`;
+    }
+    return null;
+  };
+
   // fileToDataURL removed - now using R2 upload
 
   const validateCurrentStep = () => {
@@ -360,7 +369,7 @@ const CreateServiceModal = ({ isOpen, onClose, onServiceCreated, editingService 
       case 1: // Description
         return formData.description.trim().length >= 50;
       case 2: // Pricing
-        return formData.price && parseFloat(formData.price) >= 10 && !getDiscountError();
+        return formData.price && parseFloat(formData.price) >= 10 && !getDiscountError() && !getSellerEarningsValidationError();
       case 3: // Media (optional)
         return true;
       case 4: // Preview
@@ -483,6 +492,12 @@ const CreateServiceModal = ({ isOpen, onClose, onServiceCreated, editingService 
     const discountErr = getDiscountError();
     if (discountErr) {
       showError(discountErr);
+      return;
+    }
+
+    const sellerEarningsErr = getSellerEarningsValidationError();
+    if (sellerEarningsErr) {
+      showError(sellerEarningsErr);
       return;
     }
 
@@ -846,16 +861,23 @@ const CreateServiceModal = ({ isOpen, onClose, onServiceCreated, editingService 
                   value={formData.discount}
                   onChange={(e) => handleInputChange('discount', e.target.value)}
                   min="0"
-                  max="100"
+                  max="75"
                   step="1"
                   placeholder="0"
                   className={getDiscountError() ? 'error' : ''}
                 />
-                <small>Desconto opcional (0-100%)</small>
+                <small>Desconto opcional (0-75%)</small>
                 {getDiscountError() && (
                   <div className="validation-error">
                     <i className="fas fa-exclamation-triangle"></i>
                     {getDiscountError()}
+                  </div>
+                )}
+                
+                {getSellerEarningsValidationError() && (
+                  <div className="validation-error">
+                    <i className="fas fa-exclamation-triangle"></i>
+                    {getSellerEarningsValidationError()}
                   </div>
                 )}
               </div>


### PR DESCRIPTION
Implement new discount rules for services and packs, limiting discounts to 75% and ensuring a minimum 10 VC earning for sellers.

---
<a href="https://cursor.com/background-agent?bcId=bc-15d0d6e7-e40e-42af-88ed-6000e955f41d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-15d0d6e7-e40e-42af-88ed-6000e955f41d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

