### PR TITLE
Apply glitch text style to home page headings

### DIFF
--- a/src/pages/Feed.css
+++ b/src/pages/Feed.css
@@ -22,10 +22,60 @@
   font-weight: 700;
   color: var(--text-primary);
   margin-bottom: 10px;
-  background: linear-gradient(135deg, var(--accent-color), #00ffca);
+  background: linear-gradient(135deg, #FFFFFF 20%, #8A2BE2 70%, #00FFCA 100%);
   -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
   background-clip: text;
+  color: transparent;
+  text-shadow: 0 0 20px rgba(138, 43, 226, 0.3);
+  position: relative;
+}
+
+.vixies-title h1::before,
+.vixies-title h1::after {
+  content: attr(data-text);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #FFFFFF 20%, #8A2BE2 70%, #00FFCA 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.vixies-title h1::before {
+  left: 2px;
+  text-shadow: -2px 0 #00FFCA;
+  animation: glitch-anim-1 2s infinite linear alternate-reverse;
+}
+
+.vixies-title h1::after {
+  left: -2px;
+  text-shadow: 2px 0 #8A2BE2;
+  animation: glitch-anim-2 3s infinite linear alternate-reverse;
+}
+
+@keyframes glitch-anim-1 {
+  0%, 80%, 100% {
+    opacity: 0;
+    transform: none;
+  }
+  41%, 45% {
+    opacity: 1;
+    transform: translate(-2px, 0);
+  }
+}
+
+@keyframes glitch-anim-2 {
+  0%, 80%, 100% {
+    opacity: 0;
+    transform: none;
+  }
+  61%, 65% {
+    opacity: 1;
+    transform: translate(2px, 0);
+  }
 }
 
 

--- a/src/pages/Feed.jsx
+++ b/src/pages/Feed.jsx
@@ -853,7 +853,7 @@ const Feed = () => {
       <div className="vixies-container">
       <div className="vixies-header">
         <div className="vixies-title">
-          <h1>Feed</h1>
+          <h1 data-text="Feed">Feed</h1>
         </div>
       </div>
 

--- a/src/pages/Vixies.css
+++ b/src/pages/Vixies.css
@@ -21,10 +21,60 @@
   font-weight: 700;
   color: var(--text-primary);
   margin-bottom: 10px;
-  background: linear-gradient(135deg, var(--accent-color), #00ffca);
+  background: linear-gradient(135deg, #FFFFFF 20%, #8A2BE2 70%, #00FFCA 100%);
   -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
   background-clip: text;
+  color: transparent;
+  text-shadow: 0 0 20px rgba(138, 43, 226, 0.3);
+  position: relative;
+}
+
+.vixies-title h1::before,
+.vixies-title h1::after {
+  content: attr(data-text);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #FFFFFF 20%, #8A2BE2 70%, #00FFCA 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.vixies-title h1::before {
+  left: 2px;
+  text-shadow: -2px 0 #00FFCA;
+  animation: glitch-anim-1 2s infinite linear alternate-reverse;
+}
+
+.vixies-title h1::after {
+  left: -2px;
+  text-shadow: 2px 0 #8A2BE2;
+  animation: glitch-anim-2 3s infinite linear alternate-reverse;
+}
+
+@keyframes glitch-anim-1 {
+  0%, 80%, 100% {
+    opacity: 0;
+    transform: none;
+  }
+  41%, 45% {
+    opacity: 1;
+    transform: translate(-2px, 0);
+  }
+}
+
+@keyframes glitch-anim-2 {
+  0%, 80%, 100% {
+    opacity: 0;
+    transform: none;
+  }
+  61%, 65% {
+    opacity: 1;
+    transform: translate(2px, 0);
+  }
 }
 
 

--- a/src/pages/Vixies.jsx
+++ b/src/pages/Vixies.jsx
@@ -575,7 +575,7 @@ const Vixies = () => {
       <div className="vixies-container">
       <div className="vixies-header">
         <div className="vixies-title">
-          <h1>Vixies</h1>
+          <h1 data-text="Vixies">Vixies</h1>
         </div>
       </div>
 

--- a/src/pages/Vixink.jsx
+++ b/src/pages/Vixink.jsx
@@ -531,7 +531,7 @@ const Vixink = () => {
       <div className="vixies-container">
       <div className="vixies-header">
         <div className="vixies-title">
-          <h1>Vixink</h1>
+          <h1 data-text="Vixink">Vixink</h1>
         </div>
       </div>
 


### PR DESCRIPTION
Apply glitch-text styling to the `h1` titles on Feed, Vixies, and Vixink pages to match the home page's visual effect.

---
<a href="https://cursor.com/background-agent?bcId=bc-d18978f1-68a4-4e7e-ae8b-71e389a7bf13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d18978f1-68a4-4e7e-ae8b-71e389a7bf13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

