### PR TITLE
Remove currency and vp icons from options

### DIFF
--- a/src/components/CreateServiceModal.jsx
+++ b/src/components/CreateServiceModal.jsx
@@ -968,7 +968,6 @@ const CreateServiceModal = ({ isOpen, onClose, onServiceCreated, editingService 
                             <div className="currency-row">
                               <span>Cliente paga:</span>
                               <span className="currency-value vp">
-                                <div className="currency-icon vp-icon"></div>
                                 {formatVP(convertVCtoVP(option.price))}
                               </span>
                             </div>


### PR DESCRIPTION
Remove the `currency-icon vp-icon` from complementary options because it was displayed next to the VP value and was requested to be removed.

---
<a href="https://cursor.com/background-agent?bcId=bc-c3ae3312-12cd-4537-93ef-8ca13710376d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c3ae3312-12cd-4537-93ef-8ca13710376d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

