### PR TITLE
Fix service username display in search

### DIFF
--- a/src/pages/SearchResults.jsx
+++ b/src/pages/SearchResults.jsx
@@ -4,7 +4,7 @@ import { useUser } from '../contexts/UserContext';
 import { database, db } from '../../config/firebase';
 import { getProfileUrl } from '../utils/profileUrls';
 import { ref, query, orderByChild, startAt, endAt, get } from 'firebase/database';
-import { collection, query as firestoreQuery, where, getDocs, orderBy, limit } from 'firebase/firestore';
+import { collection, query as firestoreQuery, where, getDocs, orderBy, limit, doc, getDoc } from 'firebase/firestore';
 import { Link } from 'react-router-dom';
 import './SearchResults.css';
 
@@ -122,7 +122,29 @@ const SearchResults = () => {
         return 0;
       });
 
-      return services;
+      // Populate sellerUsername for services using providerId
+      const servicesWithUsernames = await Promise.all(
+        services.map(async (service) => {
+          if (service.providerId && !service.sellerUsername) {
+            try {
+              const userRef = doc(db, 'users', service.providerId);
+              const userSnap = await getDoc(userRef);
+              if (userSnap.exists()) {
+                const userData = userSnap.data();
+                service.sellerUsername = userData.username || 'usuario';
+              } else {
+                service.sellerUsername = 'usuario';
+              }
+            } catch (error) {
+              console.error('Error fetching service provider username:', error);
+              service.sellerUsername = 'usuario';
+            }
+          }
+          return service;
+        })
+      );
+
+      return servicesWithUsernames;
     } catch (error) {
       console.error('Error searching services:', error);
       return [];
@@ -170,7 +192,30 @@ const SearchResults = () => {
         return 0;
       });
 
-      return packs;
+      // Populate sellerUsername for packs using creatorId
+      const packsWithUsernames = await Promise.all(
+        packs.map(async (pack) => {
+          if ((pack.creatorId || pack.authorId) && !pack.sellerUsername) {
+            try {
+              const userId = pack.creatorId || pack.authorId;
+              const userRef = doc(db, 'users', userId);
+              const userSnap = await getDoc(userRef);
+              if (userSnap.exists()) {
+                const userData = userSnap.data();
+                pack.sellerUsername = userData.username || 'usuario';
+              } else {
+                pack.sellerUsername = 'usuario';
+              }
+            } catch (error) {
+              console.error('Error fetching pack creator username:', error);
+              pack.sellerUsername = 'usuario';
+            }
+          }
+          return pack;
+        })
+      );
+
+      return packsWithUsernames;
     } catch (error) {
       console.error('Error searching packs:', error);
       return [];


### PR DESCRIPTION
Populate `sellerUsername` in search results for services and packs to display the creator's username.

The `sellerUsername` field was empty in search results because it was not being populated dynamically. For services, the associated user ID is `providerId`, and for packs, it's `creatorId` (with `authorId` as a fallback). This PR fetches the user's username using these respective IDs and assigns it to `sellerUsername` during the search process.

---
<a href="https://cursor.com/background-agent?bcId=bc-d4549176-6802-4043-a582-99e4b90469ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d4549176-6802-4043-a582-99e4b90469ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

