### PR TITLE
Fix cover image display error

### DIFF
--- a/src/components/CreatePackModal.jsx
+++ b/src/components/CreatePackModal.jsx
@@ -1041,9 +1041,12 @@ const CreatePackModal = ({ isOpen, onClose, onPackCreated, editingPack = null })
                   <label htmlFor="cover-image" className="upload-placeholder">
                     {coverImagePreview ? (
                       <div className="cover-image-container">
-                        {console.log('Rendering cover preview:', coverImagePreview)}
-                        <img 
-                          src={coverImagePreview}
+                        <SmartMediaViewer
+                          mediaData={coverImagePreview}
+                          type="pack"
+                          watermarked={false}
+                          isOwner={true}
+                          fallbackSrc="/images/default-pack.jpg"
                           alt="Cover preview"
                           className="image-preview"
                         />
@@ -1254,7 +1257,14 @@ const CreatePackModal = ({ isOpen, onClose, onPackCreated, editingPack = null })
                 <div className="preview-header">
                   {coverImagePreview && (
                     <div className="preview-cover-image">
-                      <img src={coverImagePreview} alt={formData.title} />
+                      <SmartMediaViewer
+                        mediaData={coverImagePreview}
+                        type="pack"
+                        watermarked={false}
+                        isOwner={true}
+                        fallbackSrc="/images/default-pack.jpg"
+                        alt={formData.title}
+                      />
                     </div>
                   )}
                   <div className="preview-service-info">

--- a/src/components/SmartMediaViewer.jsx
+++ b/src/components/SmartMediaViewer.jsx
@@ -33,7 +33,7 @@ const SmartMediaViewer = ({
       return;
     }
 
-    // If mediaData is a string, it's a regular URL
+    // If mediaData is a string, it's a regular URL or Data URL
     if (typeof mediaData === 'string') {
       setIsR2Media(false);
       setR2Key(null);
@@ -42,6 +42,12 @@ const SmartMediaViewer = ({
       let url = mediaData;
       if (url && typeof url === 'string' && url.trim()) {
         try {
+          // Handle Data URLs (base64 encoded images from FileReader)
+          if (url.startsWith('data:')) {
+            setFallbackUrl(url);
+            return;
+          }
+          
           // Test if URL is valid by trying to construct it
           if (!url.startsWith('http://') && !url.startsWith('https://')) {
             url = `https://${url}`;


### PR DESCRIPTION
Fix `TypeError: Failed to construct 'URL': Invalid URL` by adding Data URL support to `SmartMediaViewer` and using it consistently for cover image previews in `CreatePackModal`.

The `SmartMediaViewer` was attempting to validate all image sources using `new URL()`, which failed for Data URLs (base64 encoded images from `FileReader.readAsDataURL()`). This prevented cover image previews from displaying when users uploaded them for services and packs. The fix adds specific handling for Data URLs and ensures `SmartMediaViewer` is used for all relevant image previews in `CreatePackModal` for consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ae06494-13e7-481c-81fc-8c3671d94320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6ae06494-13e7-481c-81fc-8c3671d94320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

