### PR TITLE
Fix registration flow bugs

### DIFF
--- a/src/pages/Auth.css
+++ b/src/pages/Auth.css
@@ -613,6 +613,9 @@
   transition: all 0.3s ease;
   cursor: pointer;
   background: rgba(22, 22, 42, 0.5);
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
 }
 
 .radio-option:hover {
@@ -620,15 +623,33 @@
   background: rgba(138, 43, 226, 0.1);
 }
 
-.radio-option input[type="radio"]:checked ~ label {
+.radio-option input[type="radio"] {
+  margin: 0;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.radio-option input[type="radio"]:checked + .option-content .option-title {
   color: #8A2BE2;
   font-weight: bold;
+}
+
+.option-content {
+  flex: 1;
+}
+
+.option-title {
+  color: #FCFCFC;
+  font-weight: 600;
+  font-size: 1rem;
+  margin-bottom: 4px;
+  transition: all 0.3s ease;
 }
 
 .option-description {
   color: #6C6C8B;
   font-size: 0.9em;
-  margin-top: 4px;
+  margin: 0;
   line-height: 1.3;
 }
 

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -467,6 +467,15 @@ const Register = () => {
           username: normalizedUsername || '',
           accountType: formData.accountType || '',
           specialAssistance: formData.specialAssistance || false,
+          location: formData.location || 'Vixora',
+          bio: formData.bio || '',
+          languages: formData.languages || '',
+          interests: formData.interests || [],
+          communicationPreferences: {
+            emailNotifications: formData.emailNotifications,
+            marketingUpdates: formData.marketingUpdates
+          },
+          avatarType: formData.avatarChoice || null,
           followersCount: 0,
           followingCount: 0,
           profilePictureURL: user.photoURL || null,
@@ -836,7 +845,7 @@ const Register = () => {
           <strong>Importante:</strong> O tipo de conta não poderá ser alterado após a criação. Escolha com cuidado.
         </div>
         <div className="radio-options">
-          <div className="radio-option">
+          <label className="radio-option" htmlFor="account-type-provider">
             <input
               type="radio"
               id="account-type-provider"
@@ -846,10 +855,12 @@ const Register = () => {
               onChange={handleChange}
               required
             />
-            <label htmlFor="account-type-provider">Provedor de Serviços</label>
-            <p className="option-description">Quero oferecer meus serviços na plataforma</p>
-          </div>
-          <div className="radio-option">
+            <div className="option-content">
+              <div className="option-title">Provedor de Serviços</div>
+              <p className="option-description">Quero oferecer meus serviços na plataforma</p>
+            </div>
+          </label>
+          <label className="radio-option" htmlFor="account-type-client">
             <input
               type="radio"
               id="account-type-client"
@@ -859,9 +870,11 @@ const Register = () => {
               onChange={handleChange}
               required
             />
-            <label htmlFor="account-type-client">Usuário</label>
-            <p className="option-description">Quero contratar serviços de outros</p>
-          </div>
+            <div className="option-content">
+              <div className="option-title">Usuário</div>
+              <p className="option-description">Quero contratar serviços de outros</p>
+            </div>
+          </label>
         </div>
       </div>
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Improve registration UX by making account type boxes fully clickable and ensure user interests and profile details are saved to Firestore.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The original implementation for account type selection only allowed clicking the radio button itself, not the surrounding box, leading to a poor user experience. Additionally, user interests and other profile data were only being saved to the Realtime Database, not Firestore, causing data inconsistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-36214d19-ea28-4f89-9798-60120998e520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-36214d19-ea28-4f89-9798-60120998e520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

