### PR TITLE
Fix button color on workflow completion

### DIFF
--- a/src/pages/MyPurchases.css
+++ b/src/pages/MyPurchases.css
@@ -662,14 +662,14 @@
 }
 
 .purchase-card.completed .btn-primary.disabled {
-  background: #666;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   color: #999;
   cursor: not-allowed;
   opacity: 0.6;
 }
 
 .purchase-card.completed .btn-primary.disabled:hover {
-  background: #666;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   transform: none;
   box-shadow: none;
 }

--- a/src/pages/Wallet.css
+++ b/src/pages/Wallet.css
@@ -1160,7 +1160,15 @@
 }
 
 /* Disabled button styles */
-.btn-primary.disabled,
+.btn-primary.disabled {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important;
+  color: #999 !important;
+  border-color: #666 !important;
+  cursor: not-allowed !important;
+  pointer-events: none;
+  opacity: 0.6;
+}
+
 .btn-secondary.disabled {
   background: #666 !important;
   color: #999 !important;
@@ -1170,7 +1178,13 @@
   opacity: 0.6;
 }
 
-.btn-primary.disabled:hover,
+.btn-primary.disabled:hover {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important;
+  color: #999 !important;
+  transform: none !important;
+  box-shadow: none !important;
+}
+
 .btn-secondary.disabled:hover {
   background: #666 !important;
   color: #999 !important;


### PR DESCRIPTION
Restore the gradient background for disabled primary buttons in workflow completion and wallet sections.

The primary button was incorrectly displaying a solid black/grey background when disabled, instead of its intended gradient, due to CSS rules overriding the default gradient. This PR ensures the gradient is maintained.

---
<a href="https://cursor.com/background-agent?bcId=bc-478deea9-39ee-43f6-92f7-2fac74126d80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-478deea9-39ee-43f6-92f7-2fac74126d80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

