### PR TITLE
Add gray border to mobile menu profile

### DIFF
--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -703,7 +703,7 @@ header .vp-balance .vp-icon svg,
   gap: 12px;
   padding: 12px 16px;
   background: none;
-  border: none;
+  border: 1px solid #ccc;
   transition: all 0.2s ease;
   position: relative;
   width: 100%;


### PR DESCRIPTION
Add a thin gray border to the `.mobile-profile-info` element.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2fa7a13-ce0f-41c9-bd52-7ed0f8998afc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d2fa7a13-ce0f-41c9-bd52-7ed0f8998afc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

