### PR TITLE
Sincronizar clique de notificação mobile com desktop

### DIFF
--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -124,29 +124,6 @@ nav {
   z-index: 150;
 }
 
-/* Mobile notification button */
-.mobile-notification-btn {
-  display: flex;
-  background: none;
-  border: none;
-  color: #00FFCA;
-  font-size: 1.2rem;
-  cursor: pointer;
-  padding: 8px;
-  border-radius: 4px;
-  transition: all 0.2s ease;
-  position: relative;
-  user-select: none;
-  -webkit-tap-highlight-color: transparent;
-  min-width: 40px;
-  min-height: 40px;
-  align-items: center;
-  justify-content: center;
-  background: rgba(15, 15, 26, 0.9);
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-}
-
 /* Mobile menu button */
 .mobile-menu-btn {
   display: none;
@@ -166,27 +143,6 @@ nav {
   min-height: 40px;
   align-items: center;
   justify-content: center;
-}
-
-/* Mobile notification button states */
-.mobile-notification-btn:hover {
-  color: #B14AFF;
-  background: rgba(177, 74, 255, 0.1);
-  border-color: #B14AFF;
-}
-
-.mobile-notification-btn:active {
-  color: #C974FF;
-  background: rgba(177, 74, 255, 0.2);
-  transform: scale(0.95);
-}
-
-.mobile-notification-btn:focus {
-  outline: none;
-  color: #B14AFF;
-  background: rgba(177, 74, 255, 0.1);
-  border-color: #B14AFF;
-  box-shadow: 0 0 0 2px rgba(177, 74, 255, 0.3);
 }
 
 /* Mobile menu button states */
@@ -884,112 +840,6 @@ header .vp-balance .vp-icon svg,
 
 
 
-/* Mobile Notification Overlay */
-.mobile-notification-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
-  backdrop-filter: blur(5px);
-  z-index: 1000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 20px;
-}
-
-.mobile-notification-content {
-  background: rgba(15, 15, 26, 0.98);
-  backdrop-filter: blur(20px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 16px;
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5);
-  width: 100%;
-  max-width: 400px;
-  max-height: 70vh;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-}
-
-.mobile-notification-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 20px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(15, 15, 26, 0.8);
-}
-
-.mobile-notification-header h3 {
-  margin: 0;
-  color: #FCFCFC;
-  font-size: 1.1rem;
-  font-weight: 600;
-}
-
-.mobile-notification-close {
-  background: none;
-  border: none;
-  color: #FCFCFC;
-  font-size: 1.2rem;
-  cursor: pointer;
-  padding: 8px;
-  border-radius: 50%;
-  transition: all 0.2s ease;
-  width: 32px;
-  height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.mobile-notification-close:hover {
-  color: #B14AFF;
-  background: rgba(177, 74, 255, 0.1);
-}
-
-.mobile-notification-close:active {
-  color: #C974FF;
-  background: rgba(177, 74, 255, 0.2);
-  transform: scale(0.95);
-}
-
-.mobile-notification-body {
-  flex: 1;
-  overflow-y: auto;
-  padding: 0;
-}
-
-/* Override NotificationCenter styles for mobile overlay */
-.mobile-notification-body .notification-center {
-  position: static;
-}
-
-.mobile-notification-body .notification-dropdown {
-  position: static;
-  width: 100%;
-  max-height: none;
-  background: transparent;
-  border: none;
-  border-radius: 0;
-  box-shadow: none;
-  margin: 0;
-  padding: 0;
-}
-
-.mobile-notification-body .notification-header {
-  display: none; /* Hide duplicate header */
-}
-
-.mobile-notification-body .notification-list {
-  max-height: calc(70vh - 80px);
-  padding: 0;
-}
-
-/* Removed old mobile-notification-section styles - no longer needed */
 
 /* Old duplicate mobile-profile styles removed - using the integrated version above */
 
@@ -1078,16 +928,6 @@ header .vp-balance .vp-icon svg,
     border: 1px solid rgba(255, 255, 255, 0.1);
   }
 
-  .mobile-notification-btn {
-    font-size: 1.1rem;
-    padding: 6px;
-    min-width: 36px;
-    min-height: 36px;
-    background: rgba(15, 15, 26, 0.9);
-    backdrop-filter: blur(10px);
-    border-radius: 8px;
-    border: 1px solid rgba(255, 255, 255, 0.1);
-  }
   
   .vp-balance {
     display: none;
@@ -1207,16 +1047,6 @@ header .vp-balance .vp-icon svg,
     border: 1px solid rgba(255, 255, 255, 0.1);
   }
 
-  .mobile-notification-btn {
-    font-size: 1rem;
-    padding: 5px;
-    min-width: 32px;
-    min-height: 32px;
-    background: rgba(15, 15, 26, 0.9);
-    backdrop-filter: blur(10px);
-    border-radius: 8px;
-    border: 1px solid rgba(255, 255, 255, 0.1);
-  }
   
   .profile-picture-container {
     width: 24px;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -17,7 +17,6 @@ const Header = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const [mobileNotificationOpen, setMobileNotificationOpen] = useState(false);
 
   // No need for loadUserData anymore, UserContext handles it
   // useEffect(() => {
@@ -29,7 +28,6 @@ const Header = () => {
   // Close mobile menu when route changes
   useEffect(() => {
     setMobileMenuOpen(false);
-    setMobileNotificationOpen(false);
   }, [location.pathname]);
 
   // Debug mobile menu state
@@ -87,19 +85,6 @@ const Header = () => {
     setMobileMenuOpen(false);
   };
 
-  const toggleMobileNotification = (e) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setMobileNotificationOpen(!mobileNotificationOpen);
-    // Close mobile menu if open
-    if (mobileMenuOpen) {
-      setMobileMenuOpen(false);
-    }
-  };
-
-  const closeMobileNotification = () => {
-    setMobileNotificationOpen(false);
-  };
 
   const isActive = (path) => {
     return location.pathname === path;
@@ -397,16 +382,6 @@ const Header = () => {
 
           {/* Mobile Header Actions */}
           <div className="mobile-header-actions">
-            {/* Mobile Notification Button */}
-            {currentUser && (
-              <button 
-                className="mobile-notification-btn"
-                onClick={toggleMobileNotification}
-              >
-                <i className="fas fa-bell"></i>
-              </button>
-            )}
-            
             {/* Mobile Menu Button */}
             <button 
               className={`mobile-menu-btn ${mobileMenuOpen ? 'menu-open' : ''}`} 
@@ -609,22 +584,6 @@ const Header = () => {
 
       </div>
 
-      {/* Mobile Notification Overlay */}
-      {mobileNotificationOpen && currentUser && (
-        <div className="mobile-notification-overlay" onClick={closeMobileNotification}>
-          <div className="mobile-notification-content" onClick={(e) => e.stopPropagation()}>
-            <div className="mobile-notification-header">
-              <h3>Notificações</h3>
-              <button className="mobile-notification-close" onClick={closeMobileNotification}>
-                <i className="fas fa-times"></i>
-              </button>
-            </div>
-            <div className="mobile-notification-body">
-              <NotificationCenter />
-            </div>
-          </div>
-        </div>
-      )}
     </>
   );
 };


### PR DESCRIPTION
Unify mobile and desktop notification behavior by removing the mobile-specific notification modal and using the existing `NotificationCenter` for both.

The `NotificationCenter` component already possessed the necessary responsiveness for mobile, making the separate modal redundant and providing a less streamlined user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-0cce7a71-3915-4af0-b23c-65174d23bbf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0cce7a71-3915-4af0-b23c-65174d23bbf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

