### PR TITLE
Navigate to user profile from chat header

### DIFF
--- a/src/components/messaging/ChatInterface.css
+++ b/src/components/messaging/ChatInterface.css
@@ -110,6 +110,14 @@
 .chat-user-info {
   display: flex;
   align-items: center;
+  transition: all 0.2s ease;
+  border-radius: 8px;
+  padding: 4px;
+}
+
+.chat-user-info:hover {
+  background-color: var(--vixter-hover);
+  transform: translateY(-1px);
 }
 
 .user-avatar {
@@ -148,6 +156,11 @@
   font-weight: 600;
   color: var(--vixter-text-primary);
   margin-bottom: 2px;
+  transition: color 0.2s ease;
+}
+
+.chat-user-info:hover .user-name {
+  color: var(--vixter-accent-primary);
 }
 
 .user-status {

--- a/src/components/messaging/ChatInterface.jsx
+++ b/src/components/messaging/ChatInterface.jsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useEnhancedMessaging } from '../../contexts/EnhancedMessagingContext';
 import { useAuth } from '../../contexts/AuthContext';
 import { useNotification } from '../../contexts/NotificationContext';
+import { getProfileUrl } from '../../utils/profileUrls';
 import CachedImage from '../CachedImage';
 import './ChatInterface.css';
 
@@ -20,6 +22,7 @@ const ChatInterface = ({ conversation, onClose }) => {
   
   const { currentUser } = useAuth();
   const { showError } = useNotification();
+  const navigate = useNavigate();
   
   const [messageText, setMessageText] = useState('');
   // Removed old typing state - now using context
@@ -35,6 +38,14 @@ const ChatInterface = ({ conversation, onClose }) => {
   const [keyboardHeight, setKeyboardHeight] = useState(0);
 
   const otherUser = getOtherParticipant(conversation);
+
+  // Handle profile navigation
+  const handleProfileClick = () => {
+    if (otherUser && otherUser.id) {
+      const profileUrl = getProfileUrl(otherUser);
+      navigate(profileUrl);
+    }
+  };
 
   // Check if user is near bottom to determine auto-scroll behavior
   const isNearBottom = () => {
@@ -270,7 +281,7 @@ const ChatInterface = ({ conversation, onClose }) => {
     >
       {/* Chat Header */}
       <div className="chat-header">
-        <div className="chat-user-info">
+        <div className="chat-user-info" onClick={handleProfileClick} style={{ cursor: 'pointer' }}>
           <div className="user-avatar">
             {(otherUser.photoURL || otherUser.profilePictureURL) ? (
               <img 


### PR DESCRIPTION
Make the chat header (avatar and name) in 1:1 conversations clickable to redirect to the user's profile.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ae78c14-efb6-43d1-a0d2-ee41e9f37fae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5ae78c14-efb6-43d1-a0d2-ee41e9f37fae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

