### PR TITLE
Debug api start call error

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -8,6 +8,13 @@ export default defineConfig({
   server: {
     // Handle SPA routing - serve index.html for all routes
     historyApiFallback: true,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+        secure: false,
+      },
+    },
   },
   build: {
     chunkSizeWarningLimit: 1024,


### PR DESCRIPTION
Add Vite proxy configuration to forward API calls to the backend, resolving 405 errors.

The frontend (Vite, `localhost:5173`) was attempting to call backend API routes (Next.js, `localhost:3001`) directly, resulting in 405 "Method Not Allowed" errors because the API endpoint was not found on the frontend's host. This change configures Vite to proxy `/api/*` requests to the correct backend server.

---
<a href="https://cursor.com/background-agent?bcId=bc-d3cfaf1b-c002-4edb-9621-1b2cbcc6a260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d3cfaf1b-c002-4edb-9621-1b2cbcc6a260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

